### PR TITLE
Remove int typehint on IDs for FreeCompany & Linkshell

### DIFF
--- a/src/XIVAPI/Api/FreeCompany.php
+++ b/src/XIVAPI/Api/FreeCompany.php
@@ -18,7 +18,7 @@ class FreeCompany
         ]);
     }
 
-    public function get(int $id, array $data = [])
+    public function get($id, array $data = [])
     {
         $options = [
             RequestOptions::QUERY
@@ -31,12 +31,12 @@ class FreeCompany
         return Guzzle::get("/freecompany/{$id}", $options);
     }
 
-    public function update(int $id)
+    public function update($id)
     {
         return Guzzle::get("/freecompany/{$id}/update");
     }
 
-    public function delete(int $id)
+    public function delete($id)
     {
         return Guzzle::get("/freecompany/{$id}/delete");
     }

--- a/src/XIVAPI/Api/Linkshell.php
+++ b/src/XIVAPI/Api/Linkshell.php
@@ -18,7 +18,7 @@ class Linkshell
         ]);
     }
 
-    public function get(int $id, array $data = [])
+    public function get($id, array $data = [])
     {
         $options = [
             RequestOptions::QUERY
@@ -31,12 +31,12 @@ class Linkshell
         return Guzzle::get("/linkshell/{$id}", $options);
     }
 
-    public function update(int $id)
+    public function update($id)
     {
         return Guzzle::get("/linkshell/{$id}/update");
     }
 
-    public function delete(int $id)
+    public function delete($id)
     {
         return Guzzle::get("/linkshell/{$id}/delete");
     }


### PR DESCRIPTION
FreeCompany ID's are getting too large to fit in an int. I remove the typehint all together to keep backwards compatibility, so now you can pass an int or string.